### PR TITLE
Fix Hugo compatibility issues

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,8 @@ defaultContentLanguage = "en"
 # googleAnalytics = ""
 
 # Define the number of posts per page
-paginate = 50
+[pagination]
+pagerSize = 50
 
 [menu]
 
@@ -192,7 +193,7 @@ paginate = 50
       """
 
 [Permalinks]
-    blog = "/blog/:year/:month/:day/:filename/"
+    blog = "/blog/:year/:month/:day/:contentbasename/"
 
 # Enable or disable top bar with social icons
 [params.topbar]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  HUGO_VERSION = "0.105.0"
+  HUGO_VERSION = "0.144.0"
 
 [context.deploy-preview]
   command = "hugo --buildFuture"

--- a/themes/hugo-universal-theme/layouts/_default/single.html
+++ b/themes/hugo-universal-theme/layouts/_default/single.html
@@ -32,7 +32,7 @@
                           {{ .Content }}
                         </div>
                         <!-- /#post-content -->
-                        {{ if .Site.DisqusShortname }}
+                        {{ if .Site.Params.disqusShortname }}
                         <div id="comments">
                             {{ template "_internal/disqus.html" . }}
                         </div>


### PR DESCRIPTION
This commit addresses several deprecation warnings and errors that occur when building the site with a newer version of Hugo.

The following changes were made:
- Updated `config.toml` to use `pagination.pagerSize` instead of the deprecated `paginate` key.
- Updated the permalink format in `config.toml` to use `:contentbasename` instead of the deprecated `:filename` token.
- Fixed a template error in `themes/hugo-universal-theme/layouts/_default/single.html` by changing `.Site.DisqusShortname` to `.Site.Params.disqusShortname`.
- Updated the Hugo version in `netlify.toml` from `0.105.0` to `0.144.0` to ensure the build environment is compatible with the new syntax.